### PR TITLE
Remove hard-code lang in url

### DIFF
--- a/content/greasyscripts.jsm
+++ b/content/greasyscripts.jsm
@@ -312,7 +312,7 @@ this.greasyscripts = {
 
 	openScriptsLink: function(window) {
 		var domain = getDomain(window.gBrowser.currentURI);
-		window.gBrowser.selectedTab = window.gBrowser.addTab("https://greasyfork.org/en/scripts/by-site/" + domain);
+		window.gBrowser.selectedTab = window.gBrowser.addTab("https://greasyfork.org/scripts/by-site/" + domain);
 	},
 
 	loadIntoWindow: function(window) {


### PR DESCRIPTION
Open a localized interface on greasyfork.org.

See also https://github.com/yfdyh000/greasy-scripts/commit/c01855494ab5c9492f3576ab6a43b6070575c334, the lang in api url changed will create a redirect request (http 302).
I'm not sure it is necessary or useful, so I was undo it for this pull.
